### PR TITLE
impr / simpler interface

### DIFF
--- a/script/DeployProfileTokenClaim.s.sol
+++ b/script/DeployProfileTokenClaim.s.sol
@@ -94,10 +94,9 @@ contract ClaimTokens is Script {
 
         vm.startBroadcast(privateKey);
 
-        uint16 epoch = 1;
-        uint256 profileId = 140; // TODO: test/carlosbeltran
+        uint256 profileId = 140; // test/carlosbeltran
 
-        ProfileTokenClaim(tokenClaim).claimTokens(epoch, profileId);
+        ProfileTokenClaim(tokenClaim).claimTokens(profileId);
 
         vm.stopBroadcast();
     }

--- a/src/interfaces/IProfileTokenClaim.sol
+++ b/src/interfaces/IProfileTokenClaim.sol
@@ -18,5 +18,6 @@ interface IProfileTokenClaim {
     error ExecutorInvalid();
     error NotAllowed();
 
-    function claimTokens(uint16 epoch, uint256 profileId) external;
+    function claimTokens(uint256 profileId) external;
+    function claimableAmount(uint256 profileId) external view returns (uint256);
 }


### PR DESCRIPTION
- keep epoch internal for claiming
- users can only claim for the current epoch
- unclaimed rewards rollover (global) on new epochs
- add view function `claimableAmount`