### PR TITLE
impr: enforced profile id ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ Simple contract to enable token claims. Lens Profiles can claim directly or via 
 
 ## Deployments
 
+ABI can be found at [abi/ProfileClaimToken.json](abi/ProfileClaimToken.json)
+
 | Contract Name | Mumbai | Polygon |
 | ------------- | ------------- | ------------- |
-| `ProfileTokenClaim`  | `0xb9E1af09483125D1426F6A19eeC046A320FE2054` | `0x` |
+| `ProfileTokenClaim`  | `0x1378F4E4024af3EE3dAEb11b62fC426B718014B9` | `0x` |
 
 Set your `.env` by copying `.env.template`
 

--- a/abi/ProfileClaimToken.json
+++ b/abi/ProfileClaimToken.json
@@ -1,0 +1,308 @@
+[
+    {
+        "type": "constructor",
+        "inputs": [
+            {
+                "name": "_hub",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_moduleRegistry",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "_token",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "claimAmounts",
+        "inputs": [
+            {
+                "name": "epoch",
+                "type": "uint16",
+                "internalType": "uint16"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "total",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "available",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "perProfile",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "startingProfileId",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "endingProfileId",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "claimTokens",
+        "inputs": [
+            {
+                "name": "profileId",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "claimableAmount",
+        "inputs": [
+            {
+                "name": "profileId",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "claims",
+        "inputs": [
+            {
+                "name": "epoch",
+                "type": "uint16",
+                "internalType": "uint16"
+            },
+            {
+                "name": "profileId",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "claimed",
+                "type": "bool",
+                "internalType": "bool"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "epoch",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "uint16",
+                "internalType": "uint16"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "hub",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "contract ILensProtocol"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "newEpoch",
+        "inputs": [
+            {
+                "name": "startingProfileId",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "totalAmount",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "profileCount",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "owner",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "renounceOwnership",
+        "inputs": [],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "function",
+        "name": "token",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "contract IERC20"
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "type": "function",
+        "name": "transferOwnership",
+        "inputs": [
+            {
+                "name": "newOwner",
+                "type": "address",
+                "internalType": "address"
+            }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+    },
+    {
+        "type": "event",
+        "name": "NewEpoch",
+        "inputs": [
+            {
+                "name": "epoch",
+                "type": "uint16",
+                "indexed": false,
+                "internalType": "uint16"
+            },
+            {
+                "name": "data",
+                "type": "tuple",
+                "indexed": false,
+                "internalType": "struct IProfileTokenClaim.ClaimAmountData",
+                "components": [
+                    {
+                        "name": "total",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "available",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "perProfile",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "startingProfileId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    },
+                    {
+                        "name": "endingProfileId",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                    }
+                ]
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "event",
+        "name": "OwnershipTransferred",
+        "inputs": [
+            {
+                "name": "previousOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            },
+            {
+                "name": "newOwner",
+                "type": "address",
+                "indexed": true,
+                "internalType": "address"
+            }
+        ],
+        "anonymous": false
+    },
+    {
+        "type": "error",
+        "name": "AlreadyClaimed",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "EpochEnded",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "ExecutorInvalid",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "InvalidInput",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "NoZeroAddress",
+        "inputs": []
+    },
+    {
+        "type": "error",
+        "name": "NotAllowed",
+        "inputs": []
+    }
+]

--- a/addresses.json
+++ b/addresses.json
@@ -1,6 +1,6 @@
 {
     "TESTNET": {
-        "ProfileTokenClaim": "0xb9E1af09483125D1426F6A19eeC046A320FE2054"
+        "ProfileTokenClaim": "0x1378F4E4024af3EE3dAEb11b62fC426B718014B9"
     },
     "MAINNET": {
     }

--- a/script/DeployProfileTokenClaim.s.sol
+++ b/script/DeployProfileTokenClaim.s.sol
@@ -53,7 +53,7 @@ contract NewEpoch is Script {
             revert("unsupported chain");
         } else if (block.chainid == 80001) {
             // polygon mumbai testnet config
-            tokenClaim = 0xb9E1af09483125D1426F6A19eeC046A320FE2054;
+            tokenClaim = 0x1378F4E4024af3EE3dAEb11b62fC426B718014B9;
         } else {
             revert("unsupported chain");
         }
@@ -87,7 +87,7 @@ contract ClaimTokens is Script {
             revert("unsupported chain");
         } else if (block.chainid == 80001) {
             // polygon mumbai testnet config
-            tokenClaim = 0xb9E1af09483125D1426F6A19eeC046A320FE2054;
+            tokenClaim = 0x1378F4E4024af3EE3dAEb11b62fC426B718014B9;
         } else {
             revert("unsupported chain");
         }

--- a/src/interfaces/IProfileTokenClaim.sol
+++ b/src/interfaces/IProfileTokenClaim.sol
@@ -8,11 +8,13 @@ interface IProfileTokenClaim {
         uint256 available; // decreasing on each claim
         uint256 perProfile; // claimable per profile
         uint256 startingProfileId; // users with profileId >= can claim
+        uint256 endingProfileId; // users with profileId < can claim
     }
 
     event NewEpoch(uint16 epoch, ClaimAmountData data);
 
     error NoZeroAddress();
+    error InvalidInput();
     error AlreadyClaimed();
     error EpochEnded();
     error ExecutorInvalid();


### PR DESCRIPTION
- accept `profileCount` in new epoch function to set the profile id range
- profiles that fall out of range cannot claim